### PR TITLE
Add support for building with Nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build/
 *.code-workspace
 dist/
 .cache/
+result

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,22 @@
+{ nixpkgs ? import <nixpkgs> { } }:
+let
+  inherit (nixpkgs) mkYarnPackage;
+  inherit (nixpkgs.nix-gitignore) gitignoreSource;
+in
+mkYarnPackage {
+  src = gitignoreSource [] ./.;
+  buildPhase = ''
+    yarn build-lib
+  '';
+
+  # don't do anything
+  installPhase = ''
+    # do nothing (load bearing comment)
+  '';
+
+  distPhase = ''
+    mkdir -p $out/dist
+    cp -R deps/*/dist/* $out/dist
+  '';
+  dontStrip = true;
+}


### PR DESCRIPTION
Nix will acquire a yarn, acquire all dependencies, do a build in a
reproducible environment (assuming nixpkgs remains the same version. We
will hand it a nixpkgs from the Carnap side so this is not of concern),
then emit a package with `dist/*` in it.

How to do it (once you have a Nix installed):

```
nix-build
```

It will then make a symlink at `result` pointing to the package.